### PR TITLE
Updated wget Program

### DIFF
--- a/wget.py
+++ b/wget.py
@@ -2,11 +2,21 @@
 
 # updated for Python 3
 
+# Sample usage:
+# $ python3 wget.py https://umd.edu response.txt
+
 import urllib.request
 import sys
 
 # sys.argv[1] = url
 # sys.argv[2] = file name
 
+url = sys.argv[1]
+file_name = sys.argv[2]
 
-response = urllib.request.urlretrieve(sys.argv[1], sys.argv[2])
+# Execute the request
+response = urllib.request.urlopen(url)
+
+# Store the response to a local file in the current directory
+with open(file_name, mode="wb") as response_file:
+    response_file.write(response.read())


### PR DESCRIPTION
Removed the deprecated function call to `urlretrieve` and instead use `urllib.request.urlopen()`.
Alternatively, we can use the `requests` library directly since a majority of HTTP calls and functions are available in it with a more sweeter wrapper.